### PR TITLE
Fix locale setting on SunOS

### DIFF
--- a/config/init.vim
+++ b/config/init.vim
@@ -24,6 +24,9 @@ else
     if s:uname ==# "Darwin\n"
         " in mac-terminal
         silent exec 'language en_US'
+    elseif s:uname ==# "SunOS\n"
+        " in Sun-OS terminal
+        silent exec 'lan en_US.UTF-8'
     else
         " in linux-terminal
         silent exec 'lan en_US.utf8'


### PR DESCRIPTION
SunOS kernels use the `en_US.UTF-8` style of locale definition.

This pull request makes SpaceVim work on SmartOS Base-64-LTS zones with the vim-8, git and build-essential packages installed.